### PR TITLE
no_apply: make apply variants default, remove others

### DIFF
--- a/js/dispatch_js.ml
+++ b/js/dispatch_js.ml
@@ -2,7 +2,7 @@ open Lwt
 open Result
 
 let dispatch_on_fragment ?on_failure ?(default="/") routes = 
-  let dispatch = Dispatch.dispatch_apply routes in
+  let dispatch = Dispatch.dispatch routes in
   let on_failure =
     match on_failure with
     | None   -> (fun msg -> print_endline msg; return_unit)

--- a/lib/dispatch.mli
+++ b/lib/dispatch.mli
@@ -69,21 +69,16 @@ type 'a route = (tag * string) list * typ * 'a
     The third and final component is the value that will be returned in the
     event that the route matches the path. *)
 
-val dispatch     : 'a route list -> string -> ('a * assoc * string option, string) result
-val dispatch_exn : 'a route list -> string -> 'a * assoc * string option
+val dispatch     : (assoc -> string option -> 'a) route list -> string -> ('a, string) result
+val dispatch_exn : (assoc -> string option -> 'a) route list -> string -> 'a
 (** [dispatch routes path] iterates through [routes] and selects the first one
-    that matches [path], returning with the route value any component mappings
-    and trailing path components (in the case of a prefix match). If none of the
-    [routes] matches [path], it will return an [Error] result.
+    that matches [path]. It then applies the route handler to any component
+    mappings and trailing path components (in the case of a prefix match) and
+    returns the result. If none of the [routes] matches [path], it will return
+    an [Error] result.
 
     [dispatch_exn routes path] behaves just like [dispatch routes path] except
     will raise an exception using [failwith] in the case of no matches. *)
-
-val dispatch_apply     : (assoc -> string option -> 'a) route list -> string -> ('a, string) result
-val dispatch_apply_exn : (assoc -> string option -> 'a) route list -> string -> 'a
-(** [dispatch_apply] and [dispatch_apply_exn] behave like their non-[apply]
-    counterparts except value returned by a route is a function that is applied
-    to the path component mapping and trailing path components. *)
 
 val to_dsl : (tag * string) list * typ -> string
 val of_dsl : string -> (tag * string) list * typ
@@ -107,9 +102,6 @@ module DSL : sig
       {- [of_dsl "/user/:id/*" = ([`Lit, "user"; `Var, "id"], `Prefix)]}
       {- [of_dsl "/user/:id/settings" = ([`Lit, "user"; `Var, "id"; `Var "settings"], `Exact)]}} *)
 
-  val dispatch     : 'a route list -> string -> ('a * assoc * string option, string) result
-  val dispatch_exn : 'a route list -> string -> 'a * assoc * string option
-
-  val dispatch_apply     : (assoc -> string option -> 'a) route list -> string -> ('a, string) result
-  val dispatch_apply_exn : (assoc -> string option -> 'a) route list -> string -> 'a
+  val dispatch     : (assoc -> string option -> 'a) route list -> string -> ('a, string) result
+  val dispatch_exn : (assoc -> string option -> 'a) route list -> string -> 'a
 end

--- a/lib_test/test_dispatch.ml
+++ b/lib_test/test_dispatch.ml
@@ -50,7 +50,7 @@ let empty () =
     end
 
 let single () =
-  let table = ["/", ()] in
+  let table = ["/", (fun ps p -> ((), ps, p))] in
   "a single entry for the root will dispatch the root to it"
     @? begin match dispatch table "/" with
        | Ok((), [], None) -> true
@@ -74,17 +74,17 @@ let overlap () =
   in
   let open Dispatch.DSL in
   "a leading prefix pattern gets matched"
-    @? begin match dispatch_apply table "/foo" with
+    @? begin match dispatch table "/foo" with
        | Ok "/foo" -> true
        | _         -> false
     end;
   "a trailing prefix pattern gets matched"
-    @? begin match dispatch_apply table "/bar" with
+    @? begin match dispatch table "/bar" with
        | Ok "/bar" -> true
        | _         -> false
     end;
   "a complete pattern does not get shadowed by prefix"
-    @? begin match dispatch_apply table "/foo/baz" with
+    @? begin match dispatch table "/foo/baz" with
        | Ok "/foo/baz" -> true
        | _             -> false
     end;
@@ -98,17 +98,17 @@ let keys () =
     ]
   in
   "a leading prefix pattern gets matched and keys properly assigned"
-    @? begin match dispatch_apply table "/foo/1" with
+    @? begin match dispatch table "/foo/1" with
        | Ok "1" -> true
        | _      -> false
     end;
   "a pattern with keys does not get shadowed by prefix"
-    @? begin match dispatch_apply table "/foo/1/test" with
+    @? begin match dispatch table "/foo/1/test" with
        | Ok "test" -> true
        | _         -> false
     end;
   "a pattern with interleaved keys and literals works"
-    @? begin match dispatch_apply table "/foo/1/bar/one" with
+    @? begin match dispatch table "/foo/1/bar/one" with
        | Ok "one" -> true
        | _        -> false
     end;
@@ -117,12 +117,12 @@ let keys () =
 let wildcard () =
   let table = ["/foo/*", disp_path] in
   "a trailing wildcard pattern matches just the prefix"
-    @? begin match dispatch_apply table "/foo" with
+    @? begin match dispatch table "/foo" with
        | Ok "" -> true
        | _     -> false
     end;
   "a trailing wildcard pattern matches a longer path"
-    @? begin match dispatch_apply table "/foo/bar/baz" with
+    @? begin match dispatch table "/foo/bar/baz" with
        | Ok "bar/baz" -> true
        | _            -> false
     end;


### PR DESCRIPTION
The two types of dispatch functions--apply and non-apply--were mutually implementable with just a few lines of code. Since the more common case will certainly be looking up request handlers based on a path, the apply variants should be the default. The old defaults have been deleted entirely.
