### PR TITLE
route: move route matching information to route type

### DIFF
--- a/js/dispatch_js.mli
+++ b/js/dispatch_js.mli
@@ -39,9 +39,8 @@
 open Dispatch
 
 val dispatch_on_fragment :
-  ?on_failure:(string -> unit Lwt.t) ->
-  ?default:string ->
-  (assoc -> string option -> unit Lwt.t) route list -> unit Lwt.t
+  ?on_failure:(string -> unit Lwt.t) -> ?default:string ->
+  unit Lwt.t route list -> unit Lwt.t
 (** [dispatch_on_fragment ?on_failure ?default routes] will monitor the URL
     fragment and dispatch to the appropriate hander in [routes]. In the event
     that the fragment does not match any routes, [on_failure] will be called,
@@ -52,9 +51,8 @@ module DSL : sig
   open DSL 
 
   val dispatch_on_fragment : 
-    ?on_failure:(string -> unit Lwt.t) ->
-    ?default:string ->
-    (assoc -> string option -> unit Lwt.t) DSL.route list -> unit Lwt.t
+    ?on_failure:(string -> unit Lwt.t) -> ?default:string ->
+    unit Lwt.t DSL.route list -> unit Lwt.t
   (** [dispatch_on_fragment ?on_failure ?default routes] is the same as the
       non-DSL version with the exception of the route type. *)
 end

--- a/lib/dispatch.ml
+++ b/lib/dispatch.ml
@@ -40,7 +40,7 @@ type typ =
   [ `Prefix | `Exact ]
 
 type assoc = (string * string) list
-type 'a route = (tag * string) list * typ * 'a
+type 'a route = (tag * string) list * typ * (assoc -> string option -> 'a)
 
 let path_split path =
   (* NOTE(seliopou): This was implemented manually to minimize dependencies for
@@ -129,7 +129,7 @@ let dispatch_exn routes path =
   | Error msg -> failwith msg
 
 module DSL = struct
-  type 'a route = string * 'a
+  type 'a route = string * (assoc -> string option -> 'a)
 
   let convert routes =
     List.map (fun (m, x) ->


### PR DESCRIPTION
The previous route type definition was from a version of the library that did not require route handlers to take matching information. Since the library now does require that, it's safe to move that requirement to
the route type.
