### PR TITLE
port to dune, upgrade opam metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - PINS="dispatch-js:. dispatch:."
     - PACKAGE="dispatch"
   matrix:
-  - OCAML_VERSION=4.03.0 DISTRO="alpine"
-  - OCAML_VERSION=4.04.2 DISTRO="debian-stable"
-  - OCAML_VERSION=4.04.2 DISTRO="ubuntu-16.04"
+  - OCAML_VERSION=4.03 DISTRO="alpine"
+  - OCAML_VERSION=4.04 DISTRO="debian-stable"
+  - OCAML_VERSION=4.05 DISTRO="ubuntu-lts"
+  - OCAML_VERSION=4.06 DISTRO="ubuntu-lts"
+  - OCAML_VERSION=4.07 DISTRO="ubuntu-lts"

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 .PHONY: all build clean test
 
 build:
-	jbuilder build @install
+	dune build @install
 
 all: build
 
 test:
-	jbuilder runtest
+	dune runtest
 
 install:
-	jbuilder install
+	dune install
 
 uninstall:
-	jbuilder uninstall
+	dune uninstall
 
 clean:
-	rm -rf _build *.install
+	dune clean

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ the `oUnit` package and reconfigure the build process to enable tests:
 
 ```bash
 opam install oUnit
-./configure --enable-tests
-make && make test
+dune runtest
 ```
 
 ## Usage

--- a/dispatch-js.descr
+++ b/dispatch-js.descr
@@ -1,1 +1,0 @@
-Dispatch - js_of_ocaml-specific support

--- a/dispatch-js.opam
+++ b/dispatch-js.opam
@@ -1,18 +1,29 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
-authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+authors: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-dispatch"
-dev-repo: "https://github.com/inhabitedtype/ocaml-dispatch.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
-build: [
-  [ "jbuilder" "subst" ] {pinned}
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
-]
 depends: [
-  "jbuilder" {build & >="1.0+beta10"}
-  "dispatch"
-  "js_of_ocaml-lwt"
+  "ocaml" {>= "4.03.0"}
+  "dune" {build & >= "1.0"}
+  "dispatch" {>="0.4.0"}
+  "js_of_ocaml-lwt" {>="3.3.0"}
   "result"
 ]
-available: [ocaml-version >= "4.03.0"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/inhabitedtype/ocaml-dispatch.git"
+synopsis: "Path-based dispatch: js_of_ocaml-specific support"
+description: """
+ocaml-dispatch provides a basic mechanism for dispatching a request to a
+handler based on hierarchical path names conventionally found in URIs. It can be
+used both for dispatching requests in a server, as well as handing changes to
+hierarchical fragments in a client-side application.
+
+This library provides a JavaScript interface for dispatching
+events based on DOM events.
+"""
+

--- a/dispatch.descr
+++ b/dispatch.descr
@@ -1,7 +1,0 @@
-Path-based dispatching for client- and server-side applications.
-
-Dispatch provides a basic mechanism for dispatching a request to a
-handler based on hierarchical path names conventionally found in URIs.
-It can be used both for dispatching requests in a server, as well as
-handing changes to hierarchical fragments in a client-side
-application.

--- a/dispatch.opam
+++ b/dispatch.opam
@@ -1,17 +1,26 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
-authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+authors: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-dispatch"
-dev-repo: "https://github.com/inhabitedtype/ocaml-dispatch.git"
 bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
-build: [
-  [ "jbuilder" "subst" ] {pinned}
-  [ "jbuilder" "build" "-p" name "-j" jobs ]
-]
-build-test: [ [ "jbuilder" "runtest" "-p" name "-j" jobs ] ]
+doc: "https://inhabitedtype.github.io/ocaml-dispatch/"
 depends: [
-  "ounit" {test & >= "1.0.2"}
-  "jbuilder" {build & >="1.0+beta10"}
+  "ocaml" {>="4.03.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "dune" {build & >= "1.0"}
   "result"
 ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/inhabitedtype/ocaml-dispatch.git"
+synopsis: "Path-based dispatching for client- and server-side applications"
+description: """
+ocaml-dispatch provides a basic mechanism for dispatching a request to a
+handler based on hierarchical path names conventionally found in URIs. It can be
+used both for dispatching requests in a server, as well as handing changes to
+hierarchical fragments in a client-side application.
+"""

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name dispatch)

--- a/js/dispatch_js.ml
+++ b/js/dispatch_js.ml
@@ -1,5 +1,6 @@
 open Lwt
 open Result
+open Js_of_ocaml
 
 let dispatch_on_fragment ?on_failure ?(default="/") routes = 
   let dispatch = Dispatch.dispatch routes in

--- a/js/dispatch_js.mli
+++ b/js/dispatch_js.mli
@@ -48,7 +48,6 @@ val dispatch_on_fragment :
     [default], or ["/"] if no default is provided. *)
 
 module DSL : sig
-  open DSL 
 
   val dispatch_on_fragment : 
     ?on_failure:(string -> unit Lwt.t) -> ?default:string ->

--- a/js/dune
+++ b/js/dune
@@ -1,0 +1,5 @@
+(library
+ (name dispatch_js)
+ (public_name dispatch-js)
+ (preprocess (pps js_of_ocaml-ppx))
+ (libraries dispatch js_of_ocaml-lwt result))

--- a/js/jbuild
+++ b/js/jbuild
@@ -1,5 +1,0 @@
-(library
- ((name        dispatch_js)
-  (public_name dispatch-js)
-  (preprocess (pps (js_of_ocaml.ppx)))
-  (libraries   (dispatch js_of_ocaml-lwt result))))

--- a/lib/dune
+++ b/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name dispatch)
+ (synopsis "Path-based dispatching for client- and server-side applications")
+ (public_name dispatch)
+ (libraries result))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,5 +1,0 @@
-(library
- ((name        dispatch)
-  (synopsis    "Path-based dispatching for client- and server-side applications")
-  (public_name dispatch)
-  (libraries   (result))))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,8 @@
+(executables
+ (names test_dispatch)
+ (libraries dispatch oUnit))
+
+(alias
+ (name runtest)
+ (deps test_dispatch.exe)
+ (action (run %{deps} -verbose)))

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,8 +1,0 @@
-(executables
- ((names (test_dispatch))
-  (libraries (dispatch oUnit))
-))
-(alias
- ((name    runtest)
-  (deps    (test_dispatch.exe))
-  (action  (run ${<} -verbose))))


### PR DESCRIPTION
Port from jbuilder to dune, and upgrades opam metadata to the
2.0 format. This should now let `dune-release` work out of the box.

Also moves to the non-deprecated Js_of_ocaml interfaces for
non-wrapped modules.