### PR TITLE
cleanup-tests: use upstreamed versions of testables

### DIFF
--- a/dispatch.opam
+++ b/dispatch.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/inhabitedtype/ocaml-dispatch/issues"
 doc: "https://inhabitedtype.github.io/ocaml-dispatch/"
 depends: [
   "ocaml" {>="4.03.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & > "0.5.0"}
   "dune" {build & >= "1.0"}
   "result"
 ]


### PR DESCRIPTION
`always`, `never`, and `result` have been upstreamed to alcotest, so just use the versions from that library.