### PR TITLE
jsoo-deprecation: require jsoo >= 3.5.0

### DIFF
--- a/dispatch-js.opam
+++ b/dispatch-js.opam
@@ -8,7 +8,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
   "dispatch" {>="0.4.0"}
-  "js_of_ocaml-lwt" {>="3.3.0" & < "3.5.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
   "result"
 ]
 build: [

--- a/js/dispatch_js.ml
+++ b/js/dispatch_js.ml
@@ -1,6 +1,7 @@
 open Lwt
 open Result
 open Js_of_ocaml
+module Lwt_js_events = Js_of_ocaml_lwt.Lwt_js_events
 
 let dispatch_on_fragment ?on_failure ?(default="/") routes = 
   let dispatch = Dispatch.dispatch routes in


### PR DESCRIPTION
Fix deprecation warning related to Lwt_js_events.