### PR TITLE
fix code sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ let handler request =
       ; "/hello/:who/", hello_handler
       ] 
   in
-  match DSL.dispatch routes request.path with
+  match dispatch routes request.path with
   | Some handler -> handler request
   | None         -> "Not found!"
 ;;


### PR DESCRIPTION
`dispatch` is not part of the DSL module, but is instead available in
the parent Dispatch module.